### PR TITLE
4.10.0 patches

### DIFF
--- a/kernel/linux-4.10.0-gentoo-surfacepro3/multitouch.patch
+++ b/kernel/linux-4.10.0-gentoo-surfacepro3/multitouch.patch
@@ -1,0 +1,147 @@
+From ad400d472ef1ef29300eb4546361c5c8680e5ed1 Mon Sep 17 00:00:00 2001
+From: Rob Landers <landers.robert@gmail.com>
+Date: Mon, 20 Feb 2017 13:20:26 -0500
+Subject: [PATCH] Add multiouch support for Microsoft Type Cover
+
+This is based on a patch by Donavan Lance <tusklahoma@gmail.com> which was also
+based on a patch by Filipe Otamendi. Modified for kernel 4.10.0.
+
+Contributor: Kobayasi Hiroaki <buribullet@gmail.com>
+Contributor: Donavan Lance <tusklahoma@gmail.com>
+Maintainer: Robert Landers <landers.robert@gmail.com>
+
+Signed-off-by: Robert Landers <landers.robert@gmail.com>
+---
+ drivers/hid/hid-core.c          | 14 +-------------
+ drivers/hid/hid-ids.h           |  2 ++
+ drivers/hid/hid-microsoft.c     | 12 ------------
+ drivers/hid/hid-multitouch.c    | 28 ++++++++++++++++++++++++++++
+ drivers/hid/usbhid/hid-quirks.c |  2 ++
+ 5 files changed, 33 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
+index ea36b55..574b28d 100644
+--- a/drivers/hid/hid-core.c
++++ b/drivers/hid/hid-core.c
+@@ -724,13 +724,7 @@ static void hid_scan_collection(struct hid_parser *parser, unsigned type)
+ 		hid->group = HID_GROUP_SENSOR_HUB;
+ 
+ 	if (hid->vendor == USB_VENDOR_ID_MICROSOFT &&
+-	    (hid->product == USB_DEVICE_ID_MS_TYPE_COVER_PRO_3 ||
+-	     hid->product == USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2 ||
+-	     hid->product == USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP ||
+-	     hid->product == USB_DEVICE_ID_MS_TYPE_COVER_PRO_4 ||
+-	     hid->product == USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_2 ||
+-	     hid->product == USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_JP ||
+-	     hid->product == USB_DEVICE_ID_MS_POWER_COVER) &&
++	     hid->product == USB_DEVICE_ID_MS_POWER_COVER &&
+ 	    hid->group == HID_GROUP_MULTITOUCH)
+ 		hid->group = HID_GROUP_GENERIC;
+ 
+@@ -1985,12 +1979,6 @@ static const struct hid_device_id hid_have_special_driver[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_DIGITAL_MEDIA_3K) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_WIRELESS_OPTICAL_DESKTOP_3_0) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_OFFICE_KB) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_2) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_JP) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_DIGITAL_MEDIA_7K) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_DIGITAL_MEDIA_600) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_DIGITAL_MEDIA_3KV1) },
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index 350accf..3613345 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -728,9 +728,11 @@
+ #define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3    0x07dc
+ #define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2  0x07e2
+ #define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP 0x07dd
++#define USB_DEVICE_ID_MS_TYPE_COVER_3        0x07de
+ #define USB_DEVICE_ID_MS_TYPE_COVER_PRO_4 0x07e4
+ #define USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_2 0x07e8
+ #define USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_JP 0x07e9
++#define USB_DEVICE_ID_MS_SURFACE_BOOK    0x07cd
+ #define USB_DEVICE_ID_MS_POWER_COVER     0x07da
+ 
+ #define USB_VENDOR_ID_MOJO		0x8282
+diff --git a/drivers/hid/hid-microsoft.c b/drivers/hid/hid-microsoft.c
+index 74b7b84..96e7d32 100644
+--- a/drivers/hid/hid-microsoft.c
++++ b/drivers/hid/hid-microsoft.c
+@@ -274,18 +274,6 @@ static const struct hid_device_id ms_devices[] = {
+ 		.driver_data = MS_NOGET },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_COMFORT_MOUSE_4500),
+ 		.driver_data = MS_DUPLICATE_USAGES },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3),
+-		.driver_data = MS_HIDINPUT },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2),
+-		.driver_data = MS_HIDINPUT },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP),
+-		.driver_data = MS_HIDINPUT },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4),
+-		.driver_data = MS_HIDINPUT },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_2),
+-		.driver_data = MS_HIDINPUT },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_JP),
+-		.driver_data = MS_HIDINPUT },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_POWER_COVER),
+ 		.driver_data = MS_HIDINPUT },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_COMFORT_KEYBOARD),
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index 6dca668..5cbe5b3 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -1398,6 +1398,34 @@ static const struct hid_device_id mt_devices[] = {
+ 		MT_USB_DEVICE(USB_VENDOR_ID_ILITEK,
+ 			USB_DEVICE_ID_ILITEK_MULTITOUCH) },
+ 
++	/* Microsoft Type Cover 3 */
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++       MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++           USB_DEVICE_ID_MS_TYPE_COVER_PRO_3) },
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++       MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++           USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP) },
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++       MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++           USB_DEVICE_ID_MS_TYPE_COVER_3) },
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++        MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++           USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2) },
++
++    /* Microsoft Type Cover 3 */
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++        MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++            USB_DEVICE_ID_MS_TYPE_COVER_PRO_4) },
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++        MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++            USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_2) },
++
++    /* Microsoft Surface Book */
++    { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++        MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++            USB_DEVICE_ID_MS_SURFACE_BOOK) },
++
++
+ 	/* MosArt panels */
+ 	{ .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
+ 		MT_USB_DEVICE(USB_VENDOR_ID_ASUS,
+diff --git a/drivers/hid/usbhid/hid-quirks.c b/drivers/hid/usbhid/hid-quirks.c
+index 30a2977..c5d34e2 100644
+--- a/drivers/hid/usbhid/hid-quirks.c
++++ b/drivers/hid/usbhid/hid-quirks.c
+@@ -109,6 +109,8 @@ static const struct hid_blacklist {
+ 	{ USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4, HID_QUIRK_NO_INIT_REPORTS },
+ 	{ USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_2, HID_QUIRK_NO_INIT_REPORTS },
+ 	{ USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_JP, HID_QUIRK_NO_INIT_REPORTS },
++	{ USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3, HID_QUIRK_NO_INIT_REPORTS },
++	{ USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_BOOK, HID_QUIRK_NO_INIT_REPORTS },
+ 	{ USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_POWER_COVER, HID_QUIRK_NO_INIT_REPORTS },
+ 	{ USB_VENDOR_ID_MSI, USB_DEVICE_ID_MSI_GT683R_LED_PANEL, HID_QUIRK_NO_INIT_REPORTS },
+ 	{ USB_VENDOR_ID_NEXIO, USB_DEVICE_ID_NEXIO_MULTITOUCH_PTI0750, HID_QUIRK_NO_INIT_REPORTS },
+-- 
+2.10.2
+

--- a/kernel/linux-4.10.0-gentoo-surfacepro3/touchscreen.patch
+++ b/kernel/linux-4.10.0-gentoo-surfacepro3/touchscreen.patch
@@ -1,0 +1,68 @@
+From aef7bfdc4036b8fa2310d3d21c23263f6a93b11f Mon Sep 17 00:00:00 2001
+From: Rob Landers <landers.robert@gmail.com>
+Date: Mon, 20 Feb 2017 13:49:23 -0500
+Subject: [PATCH] HID: Multitouch for Surface Pro
+
+This is based on patches by Daniel Martin <consume.noise@gmail.com>.
+
+Fixes:
+- sometimes the touch panel sends invalid values
+- sometimes the touch panel may not send lift-off reports
+
+Contributor: Daniel Martin <consume.noise@gmail.com>
+Maintainer: Rob Landers <landers.robert@gmail.com>
+
+Signed-off-by: Rob Landers <landers.robert@gmail.com>
+---
+ drivers/hid/hid-multitouch.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index 6dca668..6abd4ef 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -209,7 +209,8 @@ static struct mt_class mt_classes[] = {
+ 		.quirks = MT_QUIRK_ALWAYS_VALID |
+ 			MT_QUIRK_IGNORE_DUPLICATES |
+ 			MT_QUIRK_HOVERING |
+-			MT_QUIRK_CONTACT_CNT_ACCURATE },
++			MT_QUIRK_CONTACT_CNT_ACCURATE |
++			MT_QUIRK_NOT_SEEN_MEANS_UP },
+ 	{ .name = MT_CLS_EXPORT_ALL_INPUTS,
+ 		.quirks = MT_QUIRK_ALWAYS_VALID |
+ 			MT_QUIRK_CONTACT_CNT_ACCURATE,
+@@ -624,6 +625,11 @@ static void mt_complete_slot(struct mt_device *td, struct input_dev *input)
+ 	    td->num_received >= td->num_expected)
+ 		return;
+ 
++	if (td->curdata.x == 0xffff && td->curdata.x == td->curdata.y &&
++	    td->curdata.w == 0xffff && td->curdata.w == td->curdata.h) {
++	    goto inc_num_received;
++	}
++
+ 	if (td->curvalid || (td->mtclass.quirks & MT_QUIRK_ALWAYS_VALID)) {
+ 		int active;
+ 		int slotnum = mt_compute_slot(td, input);
+@@ -667,6 +673,7 @@ static void mt_complete_slot(struct mt_device *td, struct input_dev *input)
+ 		}
+ 	}
+ 
++inc_num_received:
+ 	td->num_received++;
+ }
+ 
+@@ -1111,8 +1118,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 		return -ENOMEM;
+ 	}
+ 
+-	if (id->vendor == HID_ANY_ID && id->product == HID_ANY_ID)
++	if (id->vendor == HID_ANY_ID && id->product == HID_ANY_ID &&
++	    id->group != HID_GROUP_MULTITOUCH_WIN_8) {
+ 		td->serial_maybe = true;
++	}
+ 
+ 	/*
+ 	 * Store the initial quirk state
+-- 
+2.10.2
+

--- a/kernel/linux-4.10.0-gentoo-surfacepro3/wifi.patch
+++ b/kernel/linux-4.10.0-gentoo-surfacepro3/wifi.patch
@@ -1,0 +1,51 @@
+From 0fa9e7a6822e3cae2ede97d39d9a025f6a448c48 Mon Sep 17 00:00:00 2001
+From: Rob Landers <landers.robert@gmail.com>
+Date: Tue, 21 Feb 2017 11:12:28 -0500
+Subject: [PATCH] wifi patch
+
+This is based on a wifi patch for 4.9.x ... this brings back some critical elements
+
+Signed-off-by: Rob Landers <landers.robert@gmail.com>
+
+---
+ drivers/net/wireless/marvell/mwifiex/cfg80211.c | 3 +++
+ drivers/net/wireless/marvell/mwifiex/pcie.c     | 9 +++++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/drivers/net/wireless/marvell/mwifiex/cfg80211.c b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+index 145cc4b..0b83101 100644
+--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
++++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+@@ -418,6 +418,9 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
+ 
+ 	ps_mode = enabled;
+ 
++	mwifiex_dbg(priv->adapter, ERROR, "jpw: hacking ps_mode to false\n");
++	ps_mode = 0;
++
+ 	return mwifiex_drv_set_power(priv, &ps_mode);
+ }
+ 
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
+index 4db07da..642fb6e 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
++++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
+@@ -1692,6 +1692,15 @@ static int mwifiex_pcie_process_cmd_complete(struct mwifiex_adapter *adapter)
+ 
+ 	pkt_len = *((__le16 *)skb->data);
+ 	rx_len = le16_to_cpu(pkt_len);
++
++	if (rx_len == 0) {
++	    mwifiex_dbg(adapter, ERROR,
++	        "0 byte cmdrsp\n");
++        mwifiex_map_pci_memory(adapter, skb, MWIFIEX_UPLD_SIZE,
++            PCI_DMA_FROMDEVICE);
++        return 0;
++	}
++
+ 	skb_put(skb, MWIFIEX_UPLD_SIZE - skb->len);
+ 	skb_trim(skb, rx_len);
+ 	skb_pull(skb, INTF_HEADER_LEN);
+-- 
+2.10.2
+


### PR DESCRIPTION
resolves #17 

Includes the following patches:

- multitouch.patch: turns on the cover's touchpad functionality
- touchscreen.patch: takes some of the surface's touchscreen quirks into account
- wifi.patch: Fixes some bugs with the wifi firmware...